### PR TITLE
Provide separate bind setting to support use inside a container

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,8 +43,8 @@ type authConfig struct {
 	InsecureSkipVerify bool
 }
 type clairctlConfig struct {
-	IP, Interface, TempFolder string
-	Port                      int
+	IP, Interface, BindAddr, TempFolder string
+	Port                                int
 }
 type docker struct {
 	InsecureRegistries []string
@@ -119,6 +119,9 @@ func Init(cfgFile string, logLevel string, noClean bool) {
 	if viper.Get("clairctl.interface") == nil {
 		viper.Set("clairctl.interface", "")
 	}
+	if viper.Get("clairctl.bind_addr") == nil {
+		viper.Set("clairctl.bind_addr", "")
+	}
 	if viper.Get("clairctl.tempFolder") == nil {
 		viper.Set("clairctl.tempFolder", "/tmp/clairctl")
 	}
@@ -146,6 +149,7 @@ func values() config {
 		Clairctl: clairctlConfig{
 			IP:         viper.GetString("clairctl.ip"),
 			Port:       viper.GetInt("clairctl.port"),
+			BindAddr:   viper.GetString("clairctl.bind_addr"),
 			TempFolder: viper.GetString("clairctl.tempFolder"),
 			Interface:  viper.GetString("clairctl.interface"),
 		},

--- a/server/server.go
+++ b/server/server.go
@@ -40,7 +40,12 @@ func Serve(sURL string) error {
 }
 
 func tcpListener(sURL string) (listener net.Listener) {
-	listener, err := net.Listen("tcp", sURL)
+	listenOn := sURL
+	if viper.GetString("clairctl.bind_addr") != "" {
+		listenOn = viper.GetString("clairctl.bind_addr") + ":" + viper.GetString("clairctl.port")
+	}
+	log.Debugf("Listinging on: %s", listenOn)
+	listener, err := net.Listen("tcp", listenOn)
 	if err != nil {
 		log.Fatalf("cannot instanciate listener: %v", err)
 	}


### PR DESCRIPTION
When using a container, servers within typically need to bind to 0.0.0.0 to expose themselves
externally to the container. This change supports a separate bind address from the container's
IP that needs to be relayed to clair to deliver responses and notifications.

I'm not the original author, so it's not always easy to provide the best answer, I'm open to addressing this differently. This change tries to make a minimal change more or less in keeping with the surrounding code.