### PR TITLE
Fix Layer paths for local repos

### DIFF
--- a/clair/layering.go
+++ b/clair/layering.go
@@ -60,9 +60,12 @@ func (layers *layering) pushAll() error {
 
 		//FIXME Update to TLS
 		if config.IsLocal {
-			payload.Layer.Path += "/layer.tar"
+			// Note that the local image may include a repository name
+			payload.Layer.Path = layers.hURL + "/" + payload.Layer.Path + "/layer.tar"
+		} else {
+			payload.Layer.Path = strings.Replace(payload.Layer.Path, layers.image.Hostname(), layers.hURL, 1)
 		}
-		payload.Layer.Path = strings.Replace(payload.Layer.Path, layers.image.Hostname(), layers.hURL, 1)
+
 		if err := pushLayer(payload); err != nil {
 			log.Infof("adding layer %d/%d [%v]: %v", index+1, layerCount, lUID, err)
 			if err != ErrUnanalizedLayer {


### PR DESCRIPTION
The current implementation of the layer push code replaces the repository endpoint with the local IP. This works great for images that are being pulled from docker hub or have no repository component to their tags. It fails when the image is local, but there is a registry endpoint. If the remote registry model worked in all cases, this change would not be necessary. For the time being, it appears that clairctl doesn't work with ECR credentials, so the `--local` route is necessary.