### PR TITLE
Fix env vars

### DIFF
--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/jgsqware/clairctl/config"
+	"github.com/jgsqware/clairctl/server"
+	"github.com/spf13/cobra"
+)
+
+var listenCmd = &cobra.Command{
+	Use:   "listen",
+	Short: "Starts the server to help troubleshooting communication issues",
+	Long:  `Starts the server to help troubleshooting communication issues`,
+	Run: func(cmd *cobra.Command, args []string) {
+		sURL, err := config.LocalServerIP()
+		if err != nil {
+			fmt.Println(errInternalError)
+			log.Fatalf("retrieving internal server IP: %v", err)
+		}
+		log.Fatal(server.ServeOK(sURL))
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(listenCmd)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ var Insecure = false
 var NoClean = false
 
 var ImageName string
-var ClusterImages  map[string]struct{}
+var ClusterImages map[string]struct{}
 
 type reportConfig struct {
 	Path, Format string
@@ -77,7 +77,7 @@ func Init(cfgFile string, logLevel string, noClean bool) {
 	capnslog.SetGlobalLogLevel(lvl)
 	capnslog.SetFormatter(capnslog.NewPrettyFormatter(os.Stdout, false))
 
-	viper.SetEnvPrefix("clairctl")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	viper.SetConfigName("clairctl")        // name of config file (without extension)
 	viper.AddConfigPath("$HOME/.clairctl") // adding home directory as first search path
 	viper.AddConfigPath(".")               // adding home directory as first search path


### PR DESCRIPTION
This PR fixes ENV vars. With the current prefix `viper.SetEnvPrefix("clairctl")`, vars names should look like `CLAIRCTL_CLAIRCTL_PORT` because the config already contains a top level `clairctl:`.

Also, dots and dashes need to be replaced in ENV var names because it is not shell compliant.

Now, running clairctl with `CLAIRCTL_PORT=44488 clairctl --log-level debug push --local local/image:latest` will set the server port to 44488 on the fly.