### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,15 @@ Go to [Release](https://github.com/jgsqware/clairctl/releases) and download your
 curl -L https://raw.githubusercontent.com/jgsqware/clairctl/master/install.sh | sh
 ``` 
 
-# Docker-compose
+## Docker-compose
 
 ```bash
-$ git clone git@github.com:jgsqware/clairctl.git $GOPATH/src/github.com/jgsqware/clairctl
+$ git clone git clone https://github.com/jgsqware/clairctl.git
+$ mkdir -p $GOPATH/src/github.com/jgsqware/clairctl
+$ mv clairctl $GOPATH/src/github.com/jgsqware/
 $ cd $GOPATH/src/github.com/jgsqware/clairctl
 $ docker-compose up -d postgres
+$ docker-compose up -d clairctl
 Creating network "clairctl_default" with the default driver
 Creating clairctl_postgres_1 ...
 Creating clairctl_clair_1 ...


### PR DESCRIPTION
When I was trying to setup clairctl with docker-compose option as mentioned in the document, I faced some problems. I am proposing these changes as per steps I did to overcome the problems:


When I executed the command “git clone git@github.com:jgsqware/clairctl.git $GOPATH/src/github.com/jgsqware/clairctl” it failed with error message
=== 
[root@clair-server ~]# git clone git@github.com:jgsqware/clairctl.git $GOPATH/src/github.com/jgsqware/clairctl
Cloning into '/src/github.com/jgsqware/clairctl'...
The authenticity of host 'github.com (192.30.253.113)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
RSA key fingerprint is MD5:16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,192.30.253.113' (RSA) to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.
Please make sure you have the correct access rights and the repository exists.
[root@clair-server ~]#
=== 
So did the following to workaround the problem. If this is a generic issue which could affect many, it would be good to update the project’s README.md with the workaround so that it helps other users of clairctl.
=== 
git clone git clone https://github.com/jgsqware/clairctl.git
export GOPATH=$PATH:~/go
mkdir -p $GOPATH/src/github.com/jgsqware/clairctl
mv clairctl $GOPATH/src/github.com/jgsqware/
=== 

Then executed the commands below which passed:
=== 
cd $GOPATH/src/github.com/jgsqware/clairctl
docker-compose up -d postgres
=== 

Then executed the command “docker-compose exec clairctl clairctl health” which failed with error. I Googled about this error, examined the file docker-compose.yml. Based on it, I executed “docker-compose up -d clairctl” which is not mentioned. This is when images for clair and clairctl were downloaded and started. Then I ran “docker-compose exec clairctl clairctl health” which was successful. It would be good to add the missing command: “docker-compose up -d clairctl” to the documentation so that it helps other users of clairctl.