### PR TITLE
Fixed - Docker compose starts only postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ curl -L https://raw.githubusercontent.com/jgsqware/clairctl/master/install.sh | 
 ```bash
 $ git clone git@github.com:jgsqware/clairctl.git $GOPATH/src/github.com/jgsqware/clairctl
 $ cd $GOPATH/src/github.com/jgsqware/clairctl
-$ docker-compose up -d postgres
+$ docker-compose up -d
 Creating network "clairctl_default" with the default driver
 Creating clairctl_postgres_1 ...
 Creating clairctl_clair_1 ...


### PR DESCRIPTION
Docker compose starts only postgres service. Clair and clairctl services are not started.